### PR TITLE
Ensure transaction submitted with a valid blockhash

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gamba-react-v2",
   "private": false,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/react/src/hooks/useSendTransaction.ts
+++ b/packages/react/src/hooks/useSendTransaction.ts
@@ -109,16 +109,16 @@ export function useSendTransaction() {
       )()
 
       // Create and sign the actual transaction
-      const transaction = await createTx(computeUnitLimit, (await connection.getLatestBlockhash()).blockhash)
+      const transaction = await createTx(computeUnitLimit, (await connection.getLatestBlockhash('confirmed')).blockhash)
       const signedTransaction = await wallet.signTransaction(transaction)
 
       store.set({ state: 'sending' })
-      const txId = await connection.sendTransaction(signedTransaction, { skipPreflight: true })
+      const txId = await connection.sendTransaction(signedTransaction, { skipPreflight: true, preflightCommitment: 'confirmed' })
 
       store.set({ state: 'processing', txId })
       console.debug('TX sent', txId)
 
-      const blockhash = await connection.getLatestBlockhash()
+      const blockhash = await connection.getLatestBlockhash('confirmed')
 
       const confirmStrategy: TransactionConfirmationStrategy = {
         blockhash: blockhash.blockhash,


### PR DESCRIPTION
- Update to "confirmed" commitment level when fetching the blockhash for a transaction. [more info - Helius blog](https://www.helius.dev/blog/how-to-deal-with-blockhash-errors-on-solana)
- Bump version